### PR TITLE
set the activity to be portrait orientation. The direction will be wr…

### DIFF
--- a/app/src/main/java/com/example/getorientation/MainActivity.java
+++ b/app/src/main/java/com/example/getorientation/MainActivity.java
@@ -2,6 +2,8 @@ package com.example.getorientation;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.annotation.SuppressLint;
+import android.content.pm.ActivityInfo;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
@@ -20,8 +22,11 @@ public class MainActivity extends AppCompatActivity {
     float[] magValues, accValues;
 
 
+    @SuppressLint("SourceLockedOrientationActivity")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // the direction will be wrong when landscape, and it is not good to recreate this activity when rotate
+        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 


### PR DESCRIPTION
set the activity to be portrait orientation. The direction will be wrong when landscape, and it is not good to recreate this activity when rotate